### PR TITLE
(SIMP-1450) Update to use deconflicted 'apache'

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,8 @@
 ---
 fixtures:
   repositories:
-    apache:     "https://github.com/simp/pupmod-simp-apache"
-    auditd:     "https://github.com/simp/pupmod-simp-auditd"
+    simp_apache: "https://github.com/simp/pupmod-simp-apache"
+    auditd: "https://github.com/simp/pupmod-simp-auditd"
     augeasproviders:
       repo: "https://github.com/simp/augeasproviders"
       branch: 'simp-master'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
-* Fri Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.2.1-0
-- Update project origin to `github.com/simp`
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-0
+- Update to use the renamed 'simp_apache'
 
 * Fri Jul 29 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.2.0-0
 - Update to the new naming scheme

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,1 +1,2 @@
 Requires: pupmod-simp-iptables >= 2.0.0-0
+Requires: pupmod-simp-simp_apache >= 5.0.0-0

--- a/manifests/config/ssl.pp
+++ b/manifests/config/ssl.pp
@@ -61,18 +61,18 @@ class foreman::config::ssl (
   $passenger_ruby          = $::foreman::config::passenger_ruby,
   $server                  = $::foreman::config::server,
   $sslcacertificatefile    = '/etc/httpd/conf/pki/cacerts/cacerts.pem',
-  $sslcacertificatepath    = $::apache::ssl::sslcacertificatepath,
+  $sslcacertificatepath    = $::simp_apache::ssl::sslcacertificatepath,
   $sslcertificatechainfile = '/etc/httpd/conf/pki/cacerts/cacerts.pem',
-  $sslcertificatefile      = $::apache::ssl::sslcertificatefile,
-  $sslcertificatekeyfile   = $::apache::ssl::sslcertificatekeyfile,
-  $sslverifyclient         = $::apache::ssl::sslverifyclient,
-  $sslverifydepth          = $::apache::ssl::sslverifydepth,
+  $sslcertificatefile      = $::simp_apache::ssl::sslcertificatefile,
+  $sslcertificatekeyfile   = $::simp_apache::ssl::sslcertificatekeyfile,
+  $sslverifyclient         = $::simp_apache::ssl::sslverifyclient,
+  $sslverifydepth          = $::simp_apache::ssl::sslverifydepth,
   $vhost_root              = $::foreman::config::vhost_root
-) {
+) inherits ::simp_apache::ssl {
   assert_private()
 
-  unless defined('::apache::ssl') {
-    fail("Error: You must include '::apache::ssl' prior to 'foreman::config::ssl'")
+  unless defined('::simp_apache::ssl') {
+    fail("Error: You must include '::simp_apache::ssl' prior to 'foreman::config::ssl'")
   }
 
   validate_absolute_path($access_log)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,16 +110,16 @@ class foreman (
   include '::foreman::install'
   include '::foreman::database'
   include '::foreman::settings'
-  include '::apache::conf'
+  include '::simp_apache::conf'
   include '::foreman::passenger'
   include '::foreman::proxy'
   include '::foreman::config'
   if $use_ssl {
     # For variable references
-    include '::apache::ssl'
+    include '::simp_apache::ssl'
     include '::foreman::config::ssl'
 
-    Class['::apache::ssl'] -> Class['::foreman::config::ssl'] -> Class['::foreman::service']
+    Class['::simp_apache::ssl'] -> Class['::foreman::config::ssl'] -> Class['::foreman::service']
   }
   include '::foreman::service'
 

--- a/manifests/passenger.pp
+++ b/manifests/passenger.pp
@@ -71,7 +71,7 @@ class foreman::passenger (
 ){
   assert_private()
 
-  include '::apache::ssl'
+  include '::simp_apache::ssl'
   contain '::foreman::passenger::install'
 
   Class['::foreman::passenger::install'] ~> Apache::Add_site['foreman_passenger']

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -61,16 +61,15 @@ class foreman::ssl (
   $passenger_ruby          = $::foreman::passenger_ruby,
   $server                  = $::foreman::server,
   $sslcacertificatefile    = '/etc/httpd/conf/pki/cacerts/cacerts.pem',
-  $sslcacertificatepath    = $::apache::ssl::sslcacertificatepath,
+  $sslcacertificatepath    = $::simp_apache::ssl::sslcacertificatepath,
   $sslcertificatechainfile = '/etc/httpd/conf/pki/cacerts/cacerts.pem',
-  $sslcertificatefile      = $::apache::ssl::sslcertificatefile,
-  $sslcertificatekeyfile   = $::apache::ssl::sslcertificatekeyfile,
-  $sslverifyclient         = $::apache::ssl::sslverifyclient,
-  $sslverifydepth          = $::apache::ssl::sslverifydepth,
+  $sslcertificatefile      = $::simp_apache::ssl::sslcertificatefile,
+  $sslcertificatekeyfile   = $::simp_apache::ssl::sslcertificatekeyfile,
+  $sslverifyclient         = $::simp_apache::ssl::sslverifyclient,
+  $sslverifydepth          = $::simp_apache::ssl::sslverifydepth,
   $vhost_root              = $::foreman::vhost_root
-){
+) inherits ::simp_apache::ssl {
   include '::foreman'
-  include 'apache::ssl'
 
   apache::add_site { '05-foreman-ssl':
     content => template('foreman/etc/httpd/conf.d/05-foreman-ssl.conf.erb')

--- a/metadata.json
+++ b/metadata.json
@@ -1,21 +1,21 @@
 {
-  "name": "simp-foreman",
-  "version": "0.2.1",
-  "author": "SIMP",
+  "name":    "simp-foreman",
+  "version": "1.0.0",
+  "author":  "SIMP",
   "summary": "A puppet module to install and configure Foreman.",
   "license": "Apache-2.0",
-  "source": "https://github.com/simp/pupmod-simp-foreman",
-  "project_page": "https://github.com/simp/pupmod-simp-foreman",
-  "issues_url": "https://simp-project.atlassian.net",
-  "tags": [
-    "simp",
-    "enc",
-    "foreman"
-  ],
+  "source":  "https://github.com/kendall-moore/pupmod-simp-foreman",
+  "project_page": "https://github.com/kendall-moore/pupmod-simp-foreman",
+  "issues_url":   "https://github.com/kendall-moore/pupmod-simp-foreman/issues",
+  "tags": [ "simp", "enc", "foreman" ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp/simp_apache",
+      "version_requirement": ">= 5.0.0"
     },
     {
       "name": "simp/iptables",


### PR DESCRIPTION
This has been updated to use the new 'simp_apache' module which
deconflicts with the 'puppetlabs/apache' module.

SIMP-1450 #comment Deconflicted with puppetlabs/apache
SIMP-6 #comment Deconflicted 'foreman'
