### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,73 +1,107 @@
 ---
 fixtures:
   repositories:
-    apache:     "https://github.com/simp/pupmod-simp-apache"
-    auditd:     "https://github.com/simp/pupmod-simp-auditd"
+    apache:
+      repo: https://github.com/simp/pupmod-simp-apache
+      branch: 5.X
+    auditd:
+      repo: https://github.com/simp/pupmod-simp-auditd
+      branch: 5.X
     augeasproviders:
-      repo: "https://github.com/simp/augeasproviders"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders
     augeasproviders_base:
-      repo: "https://github.com/simp/augeasproviders_base"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_base
     augeasproviders_core:
-      repo: "https://github.com/simp/augeasproviders_core"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_core
     augeasproviders_grub:
-      repo: "https://github.com/simp/augeasproviders_grub"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_grub
     augeasproviders_puppet:
-      repo: "https://github.com/simp/augeasproviders_puppet"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_puppet
     augeasproviders_apache:
-      repo: "https://github.com/simp/augeasproviders_apache"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_apache
     augeasproviders_mounttab:
-      repo: "https://github.com/simp/augeasproviders_mounttab"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_mounttab
     augeasproviders_nagios:
-      repo: "https://github.com/simp/augeasproviders_nagios"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_nagios
     augeasproviders_pam:
-      repo: "https://github.com/simp/augeasproviders_pam"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_pam
     augeasproviders_postgresql:
-      repo: "https://github.com/simp/augeasproviders_postgresql"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_postgresql
     augeasproviders_shellvar:
-      repo: "https://github.com/simp/augeasproviders_shellvar"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_shellvar
     augeasproviders_ssh:
-      repo: "https://github.com/simp/augeasproviders_ssh"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_ssh
     augeasproviders_sysctl:
-      repo: "https://github.com/simp/augeasproviders_sysctl"
-      branch: 'simp-master'
-    compliance_markup: "https://github.com/simp/pupmod-simp-compliance_markup"
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_sysctl
+    compliance_markup:
+      repo: https://github.com/simp/pupmod-simp-compliance_markup
+      branch: 5.X
     haveged:
-      repo: "https://github.com/simp/puppet-haveged"
-      branch: "simp-master"
+      branch: 5.X
+      repo: https://github.com/simp/puppet-haveged
     inifile:
-      repo: "https://github.com/simp/puppetlabs-inifile"
-      branch: "simp-master"
-    iptables:   "https://github.com/simp/pupmod-simp-iptables"
-    logrotate:  "https://github.com/simp/pupmod-simp-logrotate"
-    pki:        "https://github.com/simp/pupmod-simp-pki"
-    pam:        "https://github.com/simp/pupmod-simp-pam"
-    pupmod:     "https://github.com/simp/pupmod-simp-pupmod"
+      branch: 5.X
+      repo: https://github.com/simp/puppetlabs-inifile
+    iptables:
+      repo: https://github.com/simp/pupmod-simp-iptables
+      branch: 5.X
+    logrotate:
+      repo: https://github.com/simp/pupmod-simp-logrotate
+      branch: 5.X
+    pki:
+      repo: https://github.com/simp/pupmod-simp-pki
+      branch: 5.X
+    pam:
+      repo: https://github.com/simp/pupmod-simp-pam
+      branch: 5.X
+    pupmod:
+      repo: https://github.com/simp/pupmod-simp-pupmod
+      branch: 5.X
     postgresql:
-      repo:   "https://github.com/simp/puppetlabs-postgresql"
-      branch: 'simp-master'
-    oddjob:     "https://github.com/simp/pupmod-simp-oddjob"
-    openldap:   "https://github.com/simp/pupmod-simp-openldap"
-    rsync:      "https://github.com/simp/pupmod-simp-rsync"
-    rsyslog:    "https://github.com/simp/pupmod-simp-rsyslog"
-    simp:       "https://github.com/simp/pupmod-simp-simp"
-    simplib:    "https://github.com/simp/pupmod-simp-simplib"
-    simpcat:    "https://github.com/simp/pupmod-simp-simpcat"
-    sssd:       "https://github.com/simp/pupmod-simp-sssd"
+      branch: 5.X
+      repo: https://github.com/simp/puppetlabs-postgresql
+    oddjob:
+      repo: https://github.com/simp/pupmod-simp-oddjob
+      branch: 5.X
+    openldap:
+      repo: https://github.com/simp/pupmod-simp-openldap
+      branch: 5.X
+    rsync:
+      repo: https://github.com/simp/pupmod-simp-rsync
+      branch: 5.X
+    rsyslog:
+      repo: https://github.com/simp/pupmod-simp-rsyslog
+      branch: 5.X
+    simp:
+      repo: https://github.com/simp/pupmod-simp-simp
+      branch: 5.X
+    simplib:
+      repo: https://github.com/simp/pupmod-simp-simplib
+      branch: 5.X
+    simpcat:
+      repo: https://github.com/simp/pupmod-simp-simpcat
+      branch: 5.X
+    sssd:
+      repo: https://github.com/simp/pupmod-simp-sssd
+      branch: 5.X
     stdlib:
-      repo: "https://github.com/simp/puppetlabs-stdlib"
-      branch: 'simp-master'
-    tcpwrappers: "https://github.com/simp/pupmod-simp-tcpwrappers"
+      branch: 5.X
+      repo: https://github.com/simp/puppetlabs-stdlib
+    tcpwrappers:
+      repo: https://github.com/simp/pupmod-simp-tcpwrappers
+      branch: 5.X
   symlinks:
     foreman: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in foreman
